### PR TITLE
Set “cursor: pointer” on body when inserting click-outside component

### DIFF
--- a/addon/mixins/click-outside.js
+++ b/addon/mixins/click-outside.js
@@ -9,10 +9,29 @@ const bound = function(fnName) {
     return this.get(fnName).bind(this);
   });
 };
+const supportsTouchEvents = () => {
+  return 'ontouchstart' in window || window.navigator.msMaxTouchPoints;
+};
 
 export default Ember.Mixin.create({
   clickOutside() {},
   clickHandler: bound('outsideClickHandler'),
+
+  didInsertElement() {
+    if (!supportsTouchEvents()) {
+      return;
+    }
+
+    $('body').css('cursor', 'pointer');
+  },
+
+  willDestroyElement() {
+    if (!supportsTouchEvents()) {
+      return;
+    }
+
+    $('body').css('cursor', '');
+  },
 
   outsideClickHandler(e) {
     const element = this.get('element');


### PR DESCRIPTION
I extracted the standalone code from our private project and added it to the `ClickOutside` mixin.

To summarize the problem: in the latest iOS (and possibly earlier versions), the `body` element must have `cursor: pointer` in order for its `click` event handlers to be triggered when the user clicks on any of its descendants that isn’t itself bound to at least one `click` event handler.

So, when a component using the `ClickOutside` mixin is inserted, we set `body`’s `cursor` to `pointer` — otherwise iOS doesn’t send the action.